### PR TITLE
Display bills in reverse order on Bill page

### DIFF
--- a/src/Frontend/src/pages/Bill/Bill.jsx
+++ b/src/Frontend/src/pages/Bill/Bill.jsx
@@ -116,7 +116,7 @@ export default function BillPage() {
 
               {/* Bills List */}
               {bills.length > 0 ? (
-                bills.map((bill) => (
+                bills.slice().reverse().map((bill) => (
                   <div key={bill.id} className="db-card" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
                     <div>
                       <h2 style={{ marginBottom: 4, fontSize: 18, fontWeight: 600 }}>Bill</h2>


### PR DESCRIPTION
Updated the bills list rendering to display bills in reverse order by applying .slice().reverse() before mapping. This ensures the most recent bills appear first.